### PR TITLE
engine-db-query: handle sys.stdout encoding

### DIFF
--- a/src/engine_db_query/__init__.py
+++ b/src/engine_db_query/__init__.py
@@ -178,6 +178,12 @@ class Database():
             with open(statement, 'r', encoding="utf-8") as f:
                 statement = f.read().strip()
 
+        if (
+            sys.stdout.encoding is None
+            or "UTF-8" not in sys.stdout.encoding.upper()
+        ):
+            statement = statement.replace("\u2014", "-")
+
         cursor = self.connection.cursor()
 
         self.logger.debug("\n\tOUTPUT TYPE: %s\n" % output_type)


### PR DESCRIPTION
This patch avoid encoding issues for the character dash
when the sys.stdout is not set or not UTF-8.

Bug-Url: https://bugzilla.redhat.com/show_bug.cgi?id=1949543