### PR TITLE
build: correct placement of buildrequirement make

### DIFF
--- a/engine-db-query.spec.in
+++ b/engine-db-query.spec.in
@@ -28,13 +28,13 @@ Source0:        https://github.com/oVirt/%{name}/releases/download/%{name}-%{ver
 
 BuildArch:      noarch
 
+BuildRequires: make
 BuildRequires: python3-devel
 
 # Autotools BuildRequires
 %if 0%{?enable_autotools}
 BuildRequires: autoconf
 BuildRequires: automake
-BuildRequires: make
 BuildRequires: gettext-devel
 BuildRequires: libtool
 %endif


### PR DESCRIPTION
## Changes introduced with this PR

* Due to centos10 not having make as standard, set it at the correct place as buildrequirement.